### PR TITLE
Allow for optional GMT

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Description
+
+## Reminders
+
+- [ ] Did you bump the version in `package.json` so that releases to npm are
+      made without version conflict?
+  - [ ] Did you also run `npm install` to update the version number in the `package.lock`?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "React component for dataset discovery UI",
   "main": "./lib/ReactDiscoveryUI.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,8 @@ import 'regenerator-runtime/runtime'
 import TagManager from 'react-gtm-module'
 window.React = React
 
-const tagManagerArgs = {
-  gtmId: window.GTM_ID
+if (window.GTM_ID) {
+  TagManager.initialize({ gtmId: window.GTM_ID });
 }
-
-TagManager.initialize(tagManagerArgs)
 
 ReactDOM.render(<ReactDiscoveryUI />, document.getElementById('root'))


### PR DESCRIPTION
## Description

- Only attempt to initialize GMT for metrics when actually provided
- Added PR template for version bump reminder

## Reminders

- [x] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [x] Did you also run `npm install` to update the version number in the `package.lock`?
