### PR TITLE
Update webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +75,7 @@ module.exports = (env, argv) => {
       contentBase: path.join(__dirname, 'dist'),
       compress: productionOptimizationsEnabled,
       open: true,
-      port: 9001
+      port: 9002
     },
     plugins: plugins,
     optimization: {


### PR DESCRIPTION
## Description

Change the default local dev port to 9002, so that it doesn't conflict with locally running minio pods on 9001 and 9002

9002 is now an allowed port for UrbanOS tenants by default, so this change will no longer break auth flow.
https://github.com/UrbanOS-Public/charts/blob/master/charts/urban-os/templates/auth0-config.yaml#L13

## Reminders

This doesn't change any published code, no package changes needed

- [ ] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [ ] Did you also run `npm install` to update the version number in the `package.lock`?
