### PR TITLE
Open download in new tab so user does not get error if preview hasn't…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.15",
+  "version": "2.1.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.15",
+  "version": "2.1.16",
   "description": "React component for dataset discovery UI",
   "main": "./lib/ReactDiscoveryUI.js",
   "repository": {

--- a/src/components/generic-elements/call-to-action-button/call-to-action-button.js
+++ b/src/components/generic-elements/call-to-action-button/call-to-action-button.js
@@ -1,4 +1,3 @@
-
 import './call-to-action-button.scss'
 import { useState } from 'react'
 import Modal from 'react-modal'
@@ -35,7 +34,7 @@ export function CallToActionButton({ url, format, sourceType, sourceUrl }) {
     } else {
       const result = await AuthenticatedHTTPClient.get(url)
       const downloadUrl = result.data + '&_format=' + format
-      window.location.href = downloadUrl
+      window.open(downloadUrl)
     }
   }
 
@@ -66,7 +65,7 @@ export function CallToActionButton({ url, format, sourceType, sourceUrl }) {
         </div>
       </Modal>
       <div>
-        <call-to-action-button className="primary-background-color">
+        <call-to-action-button className='primary-background-color'>
           <a
             data-testid='call-to-action-button'
             className='call-to-action-button'

--- a/src/components/generic-elements/call-to-action-button/call-to-action-button.test.js
+++ b/src/components/generic-elements/call-to-action-button/call-to-action-button.test.js
@@ -1,4 +1,4 @@
-import { shallow, mount } from 'enzyme'
+import { shallow } from 'enzyme'
 import CallToActionButton from './call-to-action-button'
 import Modal from 'react-modal'
 import { AuthenticatedHTTPClient } from '../../../utils/http-clients'
@@ -10,29 +10,28 @@ describe('call-to-action-button', () => {
     )
   }
 
-  test('it calls window.location.href onClick', done => {
+  beforeEach(() => {
+    window.open = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('it calls window.open onClick', done => {
     AuthenticatedHTTPClient.get = jest.fn()
+    const presignedUrl = 'http://test.example.com/api/v1/presigned/url?key=123'
     AuthenticatedHTTPClient.get.mockImplementationOnce(() => ({
       status: 200,
-      data: 'http://test.example.com/api/v1/presigned/url?key=123'
+      data: presignedUrl
     }))
-
-    const url = 'http://dummy.com'
-    Object.defineProperty(window, 'location', {
-      value: {
-        href: url
-      },
-      writable: true
-    })
-
     const subject = createCallToActionButton({ url: 'abc', format: 'csv', filename: 'dataset.csv' })
 
     subject.find('.call-to-action-button').simulate('click')
 
+    const expectedUrl = presignedUrl + '&_format=csv'
     setTimeout(() => {
-      expect(window.location.href).toEqual(
-        'http://test.example.com/api/v1/presigned/url?key=123&_format=csv'
-      )
+      expect(window.open).toBeCalledWith(expectedUrl)
       done()
     }, 100)
   })


### PR DESCRIPTION
… finished

## Description

If a Discovery user clicks the download button on the dataset details page before the preview has finished loading, the download will work but the page will show an "unable to retrieve datasets" error. This happens because the download button is changing the window.location.href, aborting the dataset retrieval and reloading the page. This PR has the download open in a new tab, which will briefly open and then close a new tab to begin the download.

## Reminders

- [x] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [x] Did you also run `npm install` to update the version number in the `package.lock`?
- If you'd like to see this code deployed after merge, don't forget to cut a release in this repo, then update the package versions in [discovery-ui](https://github.com/UrbanOS-public/discovery_ui)