### PR TITLE
Restoring focus after results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "description": "React component for dataset discovery UI",
   "main": "./lib/ReactDiscoveryUI.js",
   "repository": {

--- a/src/components/facet-list/facet-list.js
+++ b/src/components/facet-list/facet-list.js
@@ -24,6 +24,7 @@ const FacetList = props => {
           .slice(0, props.limit)
           .map(({ name, count, selected }) => (
             <Checkbox
+              id={`facet-list-${name}`}
               clickHandler={() => props.clickHandler(name)}
               text={getText(name, count)}
               selected={selected}

--- a/src/components/generic-elements/checkbox/checkbox.js
+++ b/src/components/generic-elements/checkbox/checkbox.js
@@ -18,6 +18,7 @@ const Checkbox = props => {
 
   return (
     <div
+      id={props.id}
       className={`checkbox ${props.disabled ? 'disabled' : ''} ${props.selected ? 'selected' : ''}`}
       role='button'
       tabIndex='0'

--- a/src/components/visualizations/geojson/geojson-visualization.js
+++ b/src/components/visualizations/geojson/geojson-visualization.js
@@ -100,6 +100,7 @@ export default class GeoJSONVisualization extends React.Component {
       <CollapsableBox title='Map Preview' headerHtml={description} expanded>
         <div>
           <Checkbox
+            id='toggleFullDataset'
             clickHandler={() => this.onMapToggleClick()}
             text='Show Full Dataset'
             selected={this.state.showFullMap}

--- a/src/pages/dataset-list-view/dataset-list-view.js
+++ b/src/pages/dataset-list-view/dataset-list-view.js
@@ -84,6 +84,7 @@ const DatasetListView = (props) => {
         <Auth0LoginZone />
         <div style={{ height: '0.5rem' }}>
           <Checkbox
+            id='toggleAPIDatasets'
             clickHandler={searchParamsManager.toggleApiAccessible}
             text='Only Show API Accessible Datasets'
             selected={searchParamsManager.apiAccessible}

--- a/src/search-params/search-params-manager.js
+++ b/src/search-params/search-params-manager.js
@@ -60,7 +60,6 @@ class SearchParamsManager {
   toggleFacet (name, value) {
     const facetValues = this.facets[name]
     const updatedFacets = Object.assign({}, this.facets, { [name]: _.xor(facetValues, [value]) })
-
     this.updateParams({ facets: updatedFacets, page: 1 })
   }
 
@@ -78,6 +77,7 @@ class SearchParamsManager {
   }
 
   updateParams (params) {
+    this.cacheFocusedElement()
     const updatedSearch = Object.assign({}, this.params, params)
     const updatedSearchEncoded = qs.stringify(
       updatedSearch,
@@ -85,6 +85,15 @@ class SearchParamsManager {
     )
 
     this.pushHistory({ search: updatedSearchEncoded })
+  }
+
+  cacheFocusedElement(){
+    var focusedElement = document.activeElement;
+    var focusedID = null;
+    if (focusedElement !== null && focusedElement !== document.body){
+      focusedID = focusedElement.id
+    }
+    sessionStorage.setItem("cachedFocusedElement", focusedID)
   }
 }
 
@@ -107,6 +116,13 @@ const withSearchParamsManager = (WrappedComponent) => {
     const searchParamsManager = new SearchParamsManager(history)
 
     const dispatchDatasetSearch = () => {
+      try{
+        var cachedElementID = sessionStorage.getItem("cachedFocusedElement")
+        sessionStorage.removeItem("cachedFocusedElement")
+        var cachedElement = document.getElementById(cachedElementID)
+        cachedElement.focus()
+      } catch (e) {}
+
       const updatedParams = searchParamsManager.getParams()
       dispatch(datasetSearch(updatedParams))
     }

--- a/src/search-params/search-params-manager.test.js
+++ b/src/search-params/search-params-manager.test.js
@@ -443,6 +443,20 @@ describe('withSearchParamsManager', () => {
     expect(store.getState()).toContainEqual(datasetSearch(expect.objectContaining({ apiAccessible: true })))
   })
 
+  it('refocuses any cached element after the search', () => {
+    let fakeElementId = 'fakeElement'
+    let fakeElement = {focus: jest.fn()}
+    sessionStorage.setItem('cachedFocusedElement', fakeElementId)
+    document.getElementById = jest.fn(() => fakeElement)
+
+    const subject = mount(
+      <TestableProvider store={store}>
+        <Rapper history={{ location: { search: '?apiAccessible=false' } }} />
+      </TestableProvider>)
+
+    expect(fakeElement.focus).toHaveBeenCalledTimes(1)
+  })
+
   it('does not dispatch search on other updates', () => {
     const subject = mount(
       <TestableProvider store={store}>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,7 +89,7 @@ module.exports = (env, argv) => {
       historyApiFallback: true,
       compress: productionOptimizationsEnabled,
       open: true,
-      port: 9002
+      port: 9001
     },
     plugins: plugins,
     optimization: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,7 +89,7 @@ module.exports = (env, argv) => {
       historyApiFallback: true,
       compress: productionOptimizationsEnabled,
       open: true,
-      port: 9001
+      port: 9002
     },
     plugins: plugins,
     optimization: {


### PR DESCRIPTION
## Description
Storing focused element ID in sessionStorage before updating params and refocusing ID after results have returned

## Reminders

- [ ] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [ ] Did you also run `npm install` to update the version number in the `package.lock`?
- If you'd like to see this code deployed after merge, don't forget to cut a release in this repo, then update the package versions in [discovery-ui](https://github.com/UrbanOS-public/discovery_ui)