### PR TITLE
Bumped version of previous merge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "description": "React component for dataset discovery UI",
   "main": "./lib/ReactDiscoveryUI.js",
   "repository": {


### PR DESCRIPTION
## Description

## Reminders

- [ ] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [ ] Did you also run `npm install` to update the version number in the `package.lock`?
- If you'd like to see this code deployed after merge, don't forget to cut a release in this repo, then update the package versions in [discovery-ui](https://github.com/UrbanOS-public/discovery_ui)