### PR TITLE
1106 ada workspace delete button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "description": "React component for dataset discovery UI",
   "main": "./lib/ReactDiscoveryUI.js",
   "repository": {

--- a/src/pages/user-profile-view/user-profile-view.js
+++ b/src/pages/user-profile-view/user-profile-view.js
@@ -84,7 +84,7 @@ const UserProfileView = (props) => {
       className: 'centered',
       width: 50,
       Cell: ({ original }) => (
-        <span className='delete-icon' onClick={() => { openDeleteModalForVisualization(original.id) }}>
+        <span className='delete-icon' tabIndex='0' aria-label='Delete' role='button' onKeyDownCapture={(event) => { if (event.key === ' ' || event.key === 'Enter') { openDeleteModalForVisualization(original.id) } }} onClick={() => { openDeleteModalForVisualization(original.id) }}>
           <DeleteIcon />
         </span>
       )
@@ -104,17 +104,12 @@ const UserProfileView = (props) => {
         </div>
         <div id='user-visualizations-table'>
           <ReactTable
-            tabIndex={0}
             data={visualizations}
             columns={columns}
             defaultSorted={[{ id: 'updated', desc: true }]}
             loading={props.loading}
             defaultPageSize={10}
             className='-striped -highlight'
-            getTheadThProps={() => { return { tabIndex: '0' } }}
-            getTdProps={(state, rowInfo, _) => {
-              return rowInfo != null ? { tabIndex: '0' } : {}
-            }}
           />
         </div>
       </div>
@@ -126,8 +121,8 @@ const UserProfileView = (props) => {
         <p>Are you sure you want to delete this workspace?</p>
         {deleteFailure && <p className='modal-error-text'>There was an error deleting the visualization</p>}
         <div className='modal-button-group'>
-          <button className='modal-cancel modal-button' onClick={cancelDeletion}>Cancel</button>
-          <button className='modal-confirm modal-button' onClick={() => { confirmDeletion(datasetToDelete) }}>Delete</button>
+          <button id='workspace-delete-cancel-button' type='button' className='modal-cancel modal-button' onClick={cancelDeletion}>Cancel</button>
+          <button id='workspace-delete-confirm-button' type='button' className='modal-confirm modal-button' onClick={() => { confirmDeletion(datasetToDelete) }}>Delete</button>
         </div>
       </Modal>
     </user-profile-view>

--- a/src/pages/user-profile-view/user-profile-view.js
+++ b/src/pages/user-profile-view/user-profile-view.js
@@ -104,12 +104,17 @@ const UserProfileView = (props) => {
         </div>
         <div id='user-visualizations-table'>
           <ReactTable
+            tabIndex={0}
             data={visualizations}
             columns={columns}
             defaultSorted={[{ id: 'updated', desc: true }]}
             loading={props.loading}
             defaultPageSize={10}
             className='-striped -highlight'
+            getTheadThProps={() => { return { tabIndex: '0' } }}
+            getTdProps={(state, rowInfo, _) => {
+              return rowInfo != null ? { tabIndex: '0' } : {}
+            }}
           />
         </div>
       </div>


### PR DESCRIPTION
## Description

- Make delete workspace button accessible by tab and readable by screen readers
- Space and enter can activate the delete workspace button in addition to click
- Add button type and id to cancel and confirm delete buttons in the modal to make them readable by screen readers

Focus was already trapped inside modal once it was opened.

## Reminders

- [x] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [x] Did you also run `npm install` to update the version number in the `package.lock`?
- If you'd like to see this code deployed after merge, don't forget to cut a release in this repo, then update the package versions in [discovery-ui](https://github.com/UrbanOS-public/discovery_ui)