### PR TITLE
1117 download api docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.22",
+  "version": "2.1.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.22",
+  "version": "2.1.23",
   "description": "React component for dataset discovery UI",
   "main": "./lib/ReactDiscoveryUI.js",
   "repository": {

--- a/src/components/dataset-api-doc/dataset-api-doc.js
+++ b/src/components/dataset-api-doc/dataset-api-doc.js
@@ -125,7 +125,7 @@ function renderExamples(dataset) {
 
 export default ({ expanded, dataset }) => {
   return (
-    <dataset-api-doc>
+    <dataset-api-doc class='dataset-api-doc'>
       <CollapsableBox
         title='API Examples'
         headerHtml={renderHeader()}

--- a/src/components/dataset-details/dataset-details.js
+++ b/src/components/dataset-details/dataset-details.js
@@ -15,6 +15,7 @@ const DatasetDetails = ({ dataset, downloadUrl }) => {
       <div className='dataset-details-header'>
         <div data-testid='dataset-title' className='name'><h1>{dataset.title}</h1></div>
         <div className='buttons'>
+          <button className='print-api-docs-button'>Print API Docs</button>
           <CallToActionButton url={downloadUrl} format={getDefaultFormat(dataset)} filename={dataset.id} sourceType={dataset.sourceType} sourceUrl={dataset.sourceUrl} />
         </div>
       </div>

--- a/src/components/dataset-details/dataset-details.js
+++ b/src/components/dataset-details/dataset-details.js
@@ -11,11 +11,11 @@ const DatasetDetails = ({ dataset, downloadUrl }) => {
   }
 
   return (
-    <dataset-details>
+    <dataset-details class='dataset-details'>
       <div className='dataset-details-header'>
         <div data-testid='dataset-title' className='name'><h1>{dataset.title}</h1></div>
         <div className='buttons'>
-          <button className='print-api-docs-button'>Print API Docs</button>
+          <button className='print-api-docs-button' onClick={() => window.print()}>Print API Docs</button>
           <CallToActionButton url={downloadUrl} format={getDefaultFormat(dataset)} filename={dataset.id} sourceType={dataset.sourceType} sourceUrl={dataset.sourceUrl} />
         </div>
       </div>

--- a/src/components/dataset-details/dataset-details.test.js
+++ b/src/components/dataset-details/dataset-details.test.js
@@ -3,6 +3,7 @@ import DatasetDetails from './dataset-details'
 
 describe('dataset details', () => {
   let subject
+  jest.spyOn(window, 'print').mockReturnValue()
 
   test('card to render text based on props', () => {
     subject = shallow(<DatasetDetails dataset={{ keywords: ['COTA', 'Transit Stops'] }} />)
@@ -27,5 +28,11 @@ describe('dataset details', () => {
   test('button to download api docs', () => {
     subject = shallow(<DatasetDetails dataset={{ keywords: [] }} />)
     expect(subject.find('.print-api-docs-button').length).toEqual(1)
+  })
+
+  test('click print button to print', () => {
+    subject = shallow(<DatasetDetails dataset={{ keywords: [] }} />)
+    subject.find('.print-api-docs-button').simulate('click')
+    expect(window.print).toHaveBeenCalled()
   })
 })

--- a/src/components/dataset-details/dataset-details.test.js
+++ b/src/components/dataset-details/dataset-details.test.js
@@ -23,4 +23,9 @@ describe('dataset details', () => {
     subject = shallow(<DatasetDetails dataset={{ keywords: ['COTA', 'Transit Stops'], id: '12345' }} />)
     expect(subject.find('.keyword').filterWhere(n => { return n.text() === 'COTA' }).prop('href')).toMatch(encodeURI('/?facets[keywords][]=COTA'))
   })
+
+  test('button to download api docs', () => {
+    subject = shallow(<DatasetDetails dataset={{ keywords: [] }} />)
+    expect(subject.find('.print-api-docs-button').length).toEqual(1)
+  })
 })

--- a/src/components/dataset-dictionary/dataset-dictionary.js
+++ b/src/components/dataset-dictionary/dataset-dictionary.js
@@ -114,7 +114,7 @@ export default ({ schema, datasetId, expanded = true }) => {
   }
 
   return (
-    <dataset-dictionary>
+    <dataset-dictionary class='dataset-dictionary'>
       <CollapsableBox title={title} expanded={expanded}>
         {!isEmpty(schema) && (
           <div>

--- a/src/components/dataset-dictionary/dataset-dictionary.js
+++ b/src/components/dataset-dictionary/dataset-dictionary.js
@@ -107,7 +107,7 @@ const viewLink = datasetId => (
   </div>
 )
 
-export default ({ schema, datasetId, expanded = false }) => {
+export default ({ schema, datasetId, expanded = true }) => {
   let title = 'Data Dictionary'
   if (isEmpty(schema)) {
     title = title + ' Unavailable'

--- a/src/components/dataset-dictionary/dataset-dictionary.test.js
+++ b/src/components/dataset-dictionary/dataset-dictionary.test.js
@@ -258,12 +258,12 @@ describe('dataset dictionary', () => {
     })
   })
 
-  it('is rendered in a collapsed box by default', () => {
+  it('is rendered in an expanded box by default', () => {
     subject = shallow(<DatasetDictionary schema={basicSchema} />)
 
     const collapsableBox = subject.find(CollapsableBox)
     expect(collapsableBox.length).toBe(1)
-    expect(collapsableBox.props().expanded).toBe(false)
+    expect(collapsableBox.props().expanded).toBe(true)
   })
 
   it('renders a view link', () => {

--- a/src/components/dataset-metadata/dataset-metadata.js
+++ b/src/components/dataset-metadata/dataset-metadata.js
@@ -139,7 +139,7 @@ export default class extends Component {
     ]
 
     return (
-      <dataset-metadata>
+      <dataset-metadata class='dataset-metadata'>
         <CollapsableBox title='Additional Information' expanded>
           <ReactTable
             data={data}

--- a/src/components/dataset-quality/dataset-quality.js
+++ b/src/components/dataset-quality/dataset-quality.js
@@ -20,7 +20,7 @@ export default class extends Component {
 
   render () {
     return (
-      <dataset-quality>
+      <dataset-quality class='dataset-quality'>
         <CollapsableBox title='Completeness' headerHtml={this.streamingHeader()} expanded={false}>
           <div />
         </CollapsableBox>

--- a/src/components/dataset-recommendations/dataset-recommendations.js
+++ b/src/components/dataset-recommendations/dataset-recommendations.js
@@ -21,7 +21,7 @@ const DatasetRecommendations = (props) => {
   }
 
   return (
-    <dataset-recommendations>
+    <dataset-recommendations class='dataset-recommendations'>
       <CollapsableBox title='Recommended Datasets' expanded={false}>
         <div className='recommendation-content'>
           {recommendations.map(rec =>

--- a/src/components/generic-elements/call-to-action-button/call-to-action-button.js
+++ b/src/components/generic-elements/call-to-action-button/call-to-action-button.js
@@ -52,7 +52,7 @@ export function CallToActionButton({ url, format, sourceType, sourceUrl }) {
   }
 
   return (
-    <div className='call-to-action-container'>
+    <div>
       <Modal
         isOpen={modalIsOpen}
         style={customStyles}

--- a/src/components/generic-elements/call-to-action-button/call-to-action-button.js
+++ b/src/components/generic-elements/call-to-action-button/call-to-action-button.js
@@ -52,7 +52,7 @@ export function CallToActionButton({ url, format, sourceType, sourceUrl }) {
   }
 
   return (
-    <div>
+    <div className='call-to-action-container'>
       <Modal
         isOpen={modalIsOpen}
         style={customStyles}

--- a/src/components/generic-elements/call-to-action-button/call-to-action-button.scss
+++ b/src/components/generic-elements/call-to-action-button/call-to-action-button.scss
@@ -11,4 +11,9 @@
   margin: 1rem 1rem 1rem 0.5rem;
   align-self: flex-end;
   float: right;
+  line-height: 150%;
+}
+
+.call-to-action-container {
+  display: inline-block;
 }

--- a/src/components/streaming-api-doc/streaming-api-doc.js
+++ b/src/components/streaming-api-doc/streaming-api-doc.js
@@ -42,7 +42,7 @@ export default class extends Component {
     }
 
     return (
-      <streaming-api-doc>
+      <streaming-api-doc class='streaming-api-doc'>
         <CollapsableBox title='Websocket Streaming Example' headerHtml={this.streamingHeader()} expanded={this.props.expanded}>
           {this.streamingBody()}
         </CollapsableBox>

--- a/src/components/visualizations/geojson/geojson-visualization.js
+++ b/src/components/visualizations/geojson/geojson-visualization.js
@@ -97,7 +97,7 @@ export default class GeoJSONVisualization extends React.Component {
     }
 
     return (
-      <CollapsableBox title='Map Preview' headerHtml={description} expanded>
+      <CollapsableBox class='geo-json-visualization' title='Map Preview' headerHtml={description} expanded>
         <div>
           <Checkbox
             id='toggleFullDataset'

--- a/src/pages/dataset-detail-view/dataset-detail-view.scss
+++ b/src/pages/dataset-detail-view/dataset-detail-view.scss
@@ -7,6 +7,19 @@ dataset-detail-view {
     margin-top: 2.5rem
   }
 
+  .print-api-docs-button {
+    @include button();
+    display: inline-block;
+    padding: 1.0rem;
+    width: auto;
+    color: white;
+    letter-spacing: 0.05rem;
+    margin: 1rem 1rem 1rem 0.5rem;
+    align-self: flex-end;
+    float: right;
+    line-height: 150%;
+  }
+
   .static-file-explanation {
     border: 1px solid #D2D4D6;
     padding: 1rem;

--- a/src/pages/dataset-detail-view/dataset-detail-view.scss
+++ b/src/pages/dataset-detail-view/dataset-detail-view.scss
@@ -172,27 +172,26 @@ dataset-detail-view {
     overflow: initial !important;
   }
 
-  .tab-area {
-    display: none !important;
+  .streaming-api-doc,
+  .dataset-api-doc,
+  .dataset-dictionary {
+    display: block;
   }
 
-  .left-section {
-    display: none !important;
+  .dataset-metadata {
+    break-inside: avoid;
+    display: block;
   }
 
-  .buttons {
-    display: none !important;
-  }
-
-  #dataset-preview {
-    display: none !important;
-  }
-
-  .dataset-recommendations {
-    display: none !important;
-  }
-
-  .dataset-quality {
+  .tab-area,
+  .left-section,
+  .buttons,
+  .collapse-icon,
+  .geo-json-visualization,
+  #dataset-preview,
+  .dataset-recommendations,
+  .dataset-quality,
+  .view-link {
     display: none !important;
   }
 }

--- a/src/pages/dataset-detail-view/dataset-detail-view.scss
+++ b/src/pages/dataset-detail-view/dataset-detail-view.scss
@@ -164,3 +164,35 @@ dataset-detail-view {
   }
 
 } 
+
+@media print {
+  body, html {
+    width: 100%;
+    height: initial !important;
+    overflow: initial !important;
+  }
+
+  .tab-area {
+    display: none !important;
+  }
+
+  .left-section {
+    display: none !important;
+  }
+
+  .buttons {
+    display: none !important;
+  }
+
+  #dataset-preview {
+    display: none !important;
+  }
+
+  .dataset-recommendations {
+    display: none !important;
+  }
+
+  .dataset-quality {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
## Description

Add a print button to the dataset details page. This will print out api/streaming documentation, data dictionary, and metadata for that dataset.

I took the approach of adding descriptive classes to more sections of the dataset details page, and controlling how they behaved through targeted css (rather than creating a "no-print" class for example). Hopefully this will be easy to update in the future because the code which determines what shows on print is in one place (the .scss file).

## Reminders

- [x] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [x] Did you also run `npm install` to update the version number in the `package.lock`?
- If you'd like to see this code deployed after merge, don't forget to cut a release in this repo, then update the package versions in [discovery-ui](https://github.com/UrbanOS-public/discovery_ui)