### PR TITLE
1118 date fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.30",
+  "version": "2.1.31",
   "description": "React component for dataset discovery UI",
   "main": "./lib/ReactDiscoveryUI.js",
   "repository": {

--- a/src/utils/modified-date-string-builder.js
+++ b/src/utils/modified-date-string-builder.js
@@ -13,7 +13,7 @@ const createDateString = dataset => {
       )
     case 'stream':
       return (
-        buildDate(dataset.lastUpdatedDate, DateTime.DATETIME_MED) +
+        buildDate(dataset.lastUpdatedDate, DateTime.DATE_MED) +
         ' (Last Ingested)'
       )
     default:

--- a/src/utils/modified-date-string-builder.test.js
+++ b/src/utils/modified-date-string-builder.test.js
@@ -45,7 +45,7 @@ describe('create date string', () => {
     expect(result).toEqual('Date not provided (Last Ingested)')
   })
 
-  it('returns modified date as DATE TIME (Last ingested) for streaming datasets', () => {
+  it('returns modified date as DATE (Last ingested) for streaming datasets', () => {
     const dataset = {
       sourceType: 'stream',
       modified: 'tomorrow',
@@ -53,7 +53,7 @@ describe('create date string', () => {
     }
     const result = ModifiedDateStringBuilder.createDateString(dataset)
 
-    expect(result).toMatch(/Sep \d+, 2019, \d+:\d+ (AM|PM) \(Last Ingested\)/)
+    expect(result).toEqual('Sep 6, 2019 (Last Ingested)')
   })
 
   it('returns modified date as DATE (Last updated by provider) for ingest datasets', () => {


### PR DESCRIPTION
## Description

Make streaming date format match ingest format with only date, not datetime

## Reminders

- [ ] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [ ] Did you also run `npm install` to update the version number in the `package.lock`?
- If you'd like to see this code deployed after merge, don't forget to cut a release in this repo, then update the package versions in [discovery-ui](https://github.com/UrbanOS-public/discovery_ui)