### PR TITLE
Add a table that explains Headers right below the table for parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.33",
+  "version": "2.1.34",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.33",
+  "version": "2.1.34",
   "description": "React component for dataset discovery UI",
   "main": "./lib/ReactDiscoveryUI.js",
   "repository": {

--- a/src/components/dataset-api-doc/api-example.js
+++ b/src/components/dataset-api-doc/api-example.js
@@ -1,7 +1,16 @@
 import './api-example.scss'
 import FilterNoneIcon from '@material-ui/icons/FilterNone'
 
-export default ({ title, descriptionHtml, action, url, params, examples, headers }) => {
+const defaultHeaders = [
+  {
+    name: 'api_key',
+    default: '',
+    description: 'Include your unique api key as the value. You can generate your key by navigating to the “API Key” item on the “My Account” menu.',
+    required: false
+  }
+]
+
+export default ({ title, descriptionHtml, action, url, params, examples, headers = defaultHeaders }) => {
   return (
     <api-example>
       <div className='example-container'>
@@ -62,7 +71,7 @@ function renderHeaders(headers) {
   return (
     <div>
       <div className='example-header'>Headers</div>
-      <div className='example-parameters'>
+      <div>
         <table className='example-table'>
           <thead>
             <tr>

--- a/src/components/dataset-api-doc/api-example.js
+++ b/src/components/dataset-api-doc/api-example.js
@@ -1,7 +1,7 @@
 import './api-example.scss'
 import FilterNoneIcon from '@material-ui/icons/FilterNone'
 
-export default ({ title, descriptionHtml, action, url, params, examples }) => {
+export default ({ title, descriptionHtml, action, url, params, examples, headers }) => {
   return (
     <api-example>
       <div className='example-container'>
@@ -13,18 +13,19 @@ export default ({ title, descriptionHtml, action, url, params, examples }) => {
           </code>
         </div>
         {params && renderParameters(params)}
+        {renderHeaders(headers)}
         {examples && renderExamples(examples, url)}
       </div>
     </api-example>
   )
 }
 
-function renderParameters (params) {
+function renderParameters(params) {
   return (
     <div>
       <div className='example-header'>Optional Parameters</div>
       <div className='example-parameters'>
-        <table className='parameter-table'>
+        <table className='example-table'>
           <thead>
             <tr>
               <th>Name</th>
@@ -42,7 +43,7 @@ function renderParameters (params) {
   )
 }
 
-function renderParameter (parameter) {
+function renderParameter(parameter) {
   return (
     <tr key={`${parameter.name}`}>
       <td>
@@ -55,7 +56,45 @@ function renderParameter (parameter) {
   )
 }
 
-function renderExamples (examples, url) {
+
+
+function renderHeaders(headers) {
+  return (
+    <div>
+      <div className='example-header'>Headers</div>
+      <div className='example-parameters'>
+        <table className='example-table'>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Required</th>
+              <th>Default</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {headers.map(renderHeader)}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function renderHeader(header) {
+  return (
+    <tr key={`${header.name}`}>
+      <td>
+        <span className='pill'>{header.name}</span>
+      </td>
+      <td className="required-marker">{header.required && "X"}</td>
+      <td>{header.default}</td>
+      <td>{header.description}</td>
+    </tr>
+  )
+}
+
+function renderExamples(examples, url) {
   examples = examples.map(example => {
     example.curl = createCurlCommand(example, url)
     return example
@@ -68,7 +107,7 @@ function renderExamples (examples, url) {
   )
 }
 
-function renderExample (example, index) {
+function renderExample(example, index) {
   const copyToClipboard = (event) => {
     const textField = document.createElement('textarea')
     textField.innerText = example.curl
@@ -105,6 +144,6 @@ function renderExample (example, index) {
   )
 }
 
-function createCurlCommand (example, url) {
+function createCurlCommand(example, url) {
   return `curl -X POST '${url}' -H 'Content-Type: text/plain' -H 'api_key: USER_API_KEY_HERE' -d '${example.body}'`
 }

--- a/src/components/dataset-api-doc/api-example.scss
+++ b/src/components/dataset-api-doc/api-example.scss
@@ -53,19 +53,20 @@ api-example {
   }
 
   .parameter-example {
-    white-space:nowrap;
+    white-space: nowrap;
   }
 
-  .parameter-table {
+  .example-table {
     border-collapse: collapse;
     width: 100%
   }
 
-  .parameter-table td {
+  .example-table td {
     padding: 5px
   }
 
-  .parameter-table td, th{
+  .example-table td,
+  th {
     border: 1px solid $light-grey;
   }
 
@@ -75,5 +76,9 @@ api-example {
 
   .example-description {
     margin-bottom: 0.5rem
+  }
+
+  .required-marker {
+    text-align: center;
   }
 }

--- a/src/components/dataset-api-doc/api-example.test.js
+++ b/src/components/dataset-api-doc/api-example.test.js
@@ -2,7 +2,7 @@ import { shallow, mount } from 'enzyme'
 import ApiExample from './api-example'
 
 describe('api example', () => {
-  it('renders parameters in a table', () => {
+  it('renders parameters and headers in tables', () => {
     const params = [
       {
         name: 'bob',
@@ -22,7 +22,7 @@ describe('api example', () => {
 
     const cells = wrapper.find('td')
 
-    expect(cells.length).toBe(8)
+    expect(cells.length).toBe(12)
     expect(cells.at(0).text()).toBe('bob')
     expect(cells.at(1).text()).toBe('smith')
     expect(cells.at(2).text()).toBe('robert')
@@ -31,6 +31,10 @@ describe('api example', () => {
     expect(cells.at(5).text()).toBe('johnson')
     expect(cells.at(6).text()).toBe('william')
     expect(cells.at(7).text()).toBe('a guy named bill')
+    expect(cells.at(8).text()).toBe('api_key')
+    expect(cells.at(9).text()).toBe('')
+    expect(cells.at(10).text()).toBe('')
+    expect(cells.at(11).text()).toBe('Include your unique api key as the value. You can generate your key by navigating to the “API Key” item on the “My Account” menu.')
   })
 
   it('does not render a table of params if no params are provided', () => {

--- a/src/components/dataset-api-doc/dataset-api-doc.js
+++ b/src/components/dataset-api-doc/dataset-api-doc.js
@@ -56,6 +56,15 @@ const freestyleApiParams = [
   }
 ]
 
+const apiHeaders = [
+  {
+    name: 'api_key',
+    default: '',
+    description: 'Include your unique api key as the value. You can generate your key by navigating to the “API Key” item on the “My Account” menu.',
+    required: window.REQUIRE_API_KEY === 'true'
+  }
+]
+
 function getFreestyleApiExamples(dataset) {
   return [
     {
@@ -110,6 +119,7 @@ function renderExamples(dataset) {
         url={`${window.DISC_API_URL}/api/v1/organization/${dataset.organization.name}/dataset/${dataset.name}/query?limit=200&_format=${format}`}
         action='GET'
         params={simpleApiParams}
+        headers={apiHeaders}
       />
       <ApiExample
         title='Freestyle query'
@@ -118,6 +128,7 @@ function renderExamples(dataset) {
         action='POST'
         params={freestyleApiParams}
         examples={getFreestyleApiExamples(dataset)}
+        headers={apiHeaders}
       />
     </div>
   )

--- a/src/pages/dataset-detail-view/dataset-detail-view.scss
+++ b/src/pages/dataset-detail-view/dataset-detail-view.scss
@@ -118,7 +118,7 @@ dataset-detail-view {
     dataset-organization .description {
       display:none;
     } 
-    api-example .parameter-table {
+    api-example .example-table {
       font-size:0.8em;
       line-height:1.2;
     }


### PR DESCRIPTION
## Description

The table is exactly the same in Freestyle and simple. Required is based on REQUIRE_API_KEY value.


Screenshot with Required being marked in Freestyle



![image](https://user-images.githubusercontent.com/54278348/233162589-ca10c6de-a8fe-4d8d-b35c-f4e939814a68.png)


---------



And a screenshot where it isn't required in Simple.



![Screenshot 2023-04-19 at 1 02 36 PM](https://user-images.githubusercontent.com/54278348/233163195-aa76c36d-ae23-4f16-a76d-d57b9c56b210.png)




## Reminders

- [x] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [x] Did you also run `npm install` to update the version number in the `package.lock`?
- If you'd like to see this code deployed after merge, don't forget to cut a release in this repo, then update the package versions in [discovery-ui](https://github.com/UrbanOS-public/discovery_ui)