### PR TITLE
remove preventDefault call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.39",
+  "version": "2.1.40",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.39",
+  "version": "2.1.40",
   "description": "React component for dataset discovery UI",
   "main": "./lib/ReactDiscoveryUI.js",
   "repository": {

--- a/src/pages/user-profile-view/user-profile-view.js
+++ b/src/pages/user-profile-view/user-profile-view.js
@@ -117,7 +117,7 @@ const UserProfileView = (props) => {
         </div>
         <div id='user-visualizations-table'>
           <ReactTable
-            data={[{title: "myTitle", created: "myCreated", updated: "myUpdated"}]}
+            data={visualizations}
             columns={columns}
             defaultSorted={[{ id: 'updated', desc: true }]}
             loading={props.loading}

--- a/src/pages/user-profile-view/user-profile-view.js
+++ b/src/pages/user-profile-view/user-profile-view.js
@@ -74,7 +74,7 @@ const UserProfileView = (props) => {
       className: 'centered',
       width: 50,
       Cell: ({ original }) => (
-        <span className='delete-icon' tabIndex='0' aria-label='Delete' role='button' onKeyDownCapture={(event) => { if (event.key === ' ' || event.key === 'Enter') { event.preventDefault() && openDeleteModalForVisualization(original.id) } }} onClick={() => { openDeleteModalForVisualization(original.id) }}>
+        <span className='delete-icon' tabIndex='0' aria-label='Delete' role='button' onKeyDownCapture={(event) => { if (event.key === ' ' || event.key === 'Enter') { openDeleteModalForVisualization(original.id) } }} onClick={() => { openDeleteModalForVisualization(original.id) }}>
           <DeleteIcon />
         </span>
       )
@@ -117,7 +117,7 @@ const UserProfileView = (props) => {
         </div>
         <div id='user-visualizations-table'>
           <ReactTable
-            data={visualizations}
+            data={[{title: "myTitle", created: "myCreated", updated: "myUpdated"}]}
             columns={columns}
             defaultSorted={[{ id: 'updated', desc: true }]}
             loading={props.loading}


### PR DESCRIPTION
## Description
remove preventDefault call from delete button to allow for pressing the delete button with the enter key

## Reminders

- [x] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [x] Did you also run `npm install` to update the version number in the `package.lock`?
- If you'd like to see this code deployed after merge, don't forget to cut a release in this repo, then update the package versions in [discovery-ui](https://github.com/UrbanOS-public/discovery_ui)