### PR TITLE
bump version to trigger new build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.41",
+  "version": "2.1.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@smartcitiesdata/react-discovery-ui",
-      "version": "2.1.41",
+      "version": "2.1.42",
       "license": "ISC",
       "dependencies": {
         "@auth0/auth0-spa-js": "1.22.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "2.1.41",
+  "version": "2.1.42",
   "description": "React component for dataset discovery UI",
   "main": "./lib/ReactDiscoveryUI.js",
   "repository": {


### PR DESCRIPTION
## Description
Bump version to get security updates in new build

## Reminders

- [ ] Did you bump the version in `package.json` so that releases to npm are
      made without version conflict?
  - [ ] Did you also run `npm install` to update the version number in the `package.lock`?
- If you'd like to see this code deployed after merge, don't forget to cut a release in this repo, then update the package versions in [discovery-ui](https://github.com/UrbanOS-public/discovery_ui)